### PR TITLE
Update XeroClient.java

### DIFF
--- a/client/src/main/java/com/connectifier/xeroclient/XeroClient.java
+++ b/client/src/main/java/com/connectifier/xeroclient/XeroClient.java
@@ -128,7 +128,8 @@ public class XeroClient {
   protected ResponseType put(String endPoint, JAXBElement<?> object) {
     OAuthRequest request = new OAuthRequest(Verb.PUT, BASE_URL + endPoint);
     String contents = marshallRequest(object);
-    request.addPayload(contents);
+    request.setCharset("UTF-8"); // set character set to UTF-8
+    request.addBodyParameter("xml", contents);
     service.signRequest(token, request);
     Response response = request.send();
     if (response.getCode() != 200) {

--- a/client/src/main/java/com/connectifier/xeroclient/XeroClient.java
+++ b/client/src/main/java/com/connectifier/xeroclient/XeroClient.java
@@ -128,7 +128,7 @@ public class XeroClient {
   protected ResponseType put(String endPoint, JAXBElement<?> object) {
     OAuthRequest request = new OAuthRequest(Verb.PUT, BASE_URL + endPoint);
     String contents = marshallRequest(object);
-    request.setCharset("UTF-8"); // set character set to UTF-8
+    request.setCharset("UTF-8");
     request.addBodyParameter("xml", contents);
     service.signRequest(token, request);
     Response response = request.send();


### PR DESCRIPTION
Forcing character set for encoding the payload to be UTF-8 rather than whatever the system default Charset is.
Adding payload as a body parameter under the name "xml" rather than as anonymous attachment.
These settings as per the Xero API documentation at http://developer.xero.com/documentation/getting-started/http-requests-and-responses/